### PR TITLE
fix(order): exclude 'Ukończone' from active orders count

### DIFF
--- a/src/main/java/pl/doublecodestudio/nexuserp/application/order/service/OrderService.java
+++ b/src/main/java/pl/doublecodestudio/nexuserp/application/order/service/OrderService.java
@@ -290,11 +290,10 @@ public class OrderService {
         return new ArrayList<>(byIndex.values());
     }
 
-    private Long countOrdersByLocation(String locationCode)
+    public Long countOrdersByLocation(String locationCode)
     {
-        if(locationCode == null) locationCode = "SK1";
         Map<String, Map<String, List<Order>>> grouped = orderRepository.findByLocation(locationCode).stream()
-                .filter(order -> !order.getStatus().equals("Zamknięte"))
+                .filter(order -> !order.getStatus().equals("Zamknięte") && !order.getStatus().equals("Ukończone"))
                 .collect(Collectors.groupingBy(
                         Order::getIndex,
                         Collectors.groupingBy(Order::getProdLine)

--- a/src/main/java/pl/doublecodestudio/nexuserp/interfaces/web/order/controller/OrderController.java
+++ b/src/main/java/pl/doublecodestudio/nexuserp/interfaces/web/order/controller/OrderController.java
@@ -12,6 +12,7 @@ import pl.doublecodestudio.nexuserp.application.order.query.GetOrderByIndexQuery
 import pl.doublecodestudio.nexuserp.application.order.query.GetOrderByIndexQueryHandler;
 import pl.doublecodestudio.nexuserp.application.order.query.GetOrderByLocation;
 import pl.doublecodestudio.nexuserp.application.order.query.GetOrderByLocationHandler;
+import pl.doublecodestudio.nexuserp.application.order.service.OrderService;
 import pl.doublecodestudio.nexuserp.domain.order.entity.Order;
 import pl.doublecodestudio.nexuserp.interfaces.web.order.dto.OrderDto;
 import pl.doublecodestudio.nexuserp.interfaces.web.order.dto.OrderSummaryDto;
@@ -29,6 +30,8 @@ public class OrderController {
     private final UpdateStatusCommandHandler updateStatusCommandHandler;
     private final GetOrderByLocationHandler getOrderByLocationHandler;
 
+    private final OrderService orderService;
+
     @PostMapping
     @PreAuthorize("hasRole('ORDER_REQUESTS') or hasRole('ADMIN')")
     public ResponseEntity<List<OrderDto>> create(@RequestBody CreateOrderCommand command) {
@@ -41,6 +44,13 @@ public class OrderController {
     public ResponseEntity<List<OrderSummaryDto>> processPendingOrders(@RequestBody ProcessPendingOrdersCommand command) {
         List<OrderSummaryDto> orderDtos = processPendingOrdersCommandHandler.handle(command);
         return ResponseEntity.status(HttpStatus.OK).body(orderDtos);
+    }
+
+    @GetMapping("/count-orders")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Long> countOrders(@RequestParam String locationCode) {
+        orderService.countOrdersByLocation(locationCode);
+        return ResponseEntity.status(HttpStatus.OK).body(orderService.countOrdersByLocation(locationCode));
     }
 
     @PostMapping("/create-manual")


### PR DESCRIPTION
Update countOrdersByLocation filter to ignore orders with status 'Zamknięte' or 'Ukończone', so the per-location limit applies only to pending/in-progress orders.