### PR TITLE
fix(order): exclude 'Ukończone' from active orders count

### DIFF
--- a/src/main/java/pl/doublecodestudio/nexuserp/application/order/service/OrderService.java
+++ b/src/main/java/pl/doublecodestudio/nexuserp/application/order/service/OrderService.java
@@ -300,8 +300,12 @@ public class OrderService {
                 ));
 
         return grouped.values().stream()
-                .flatMap(prodLineMap -> prodLineMap.values().stream()) // Stream<List<Order>>
-                .mapToLong(List::size)
+                .mapToLong(Map::size)
                 .sum();
+
+//        return grouped.values().stream()
+//                .flatMap(prodLineMap -> prodLineMap.values().stream()) // Stream<List<Order>>
+//                .mapToLong(List::size)
+//                .sum();
     }
 }


### PR DESCRIPTION
Update countOrdersByLocation filter to ignore orders with status 'Zamknięte' or 'Ukończone', so the per-location limit applies only to pending/in-progress orders.