### PR TITLE
refactor(order): drop Pageable from findByIndex and adapt query handler

### DIFF
--- a/src/main/java/pl/doublecodestudio/nexuserp/application/order/query/GetOrderByIndexQueryHandler.java
+++ b/src/main/java/pl/doublecodestudio/nexuserp/application/order/query/GetOrderByIndexQueryHandler.java
@@ -1,7 +1,9 @@
 package pl.doublecodestudio.nexuserp.application.order.query;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import pl.doublecodestudio.nexuserp.domain.order.entity.Order;
 import pl.doublecodestudio.nexuserp.domain.order.port.OrderRepository;
 import pl.doublecodestudio.nexuserp.interfaces.web.order.dto.OrderDto;
 import pl.doublecodestudio.nexuserp.interfaces.web.order.mapper.OrderMapperDto;
@@ -11,14 +13,22 @@ import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class GetOrderByIndexQueryHandler {
     private final OrderRepository orderRepository;
     private final OrderMapperDto mapper;
 
     public List<OrderDto> handle(GetOrderByIndexQuery query) {
-        return orderRepository.findByIndex(query.index(), query.pageable()).stream()
+        List<OrderDto> list = orderRepository.findByIndex(query.index()).stream()
                 .filter(item -> !Objects.equals(item.getStatus(), "Ukończone"))
                 .map(mapper::toDto)
                 .toList();
+        if(list.isEmpty())
+        {
+            log.info("LIST IS EMPTY!");
+        }
+        list.forEach(item -> log.info(item.toString()));
+
+        return list;
     }
 }

--- a/src/main/java/pl/doublecodestudio/nexuserp/domain/order/port/OrderRepository.java
+++ b/src/main/java/pl/doublecodestudio/nexuserp/domain/order/port/OrderRepository.java
@@ -12,7 +12,7 @@ public interface OrderRepository {
 
     List<Order> saveAll(List<Order> orders);
 
-    List<Order> findByIndex(String batchId, Pageable pageable);
+    List<Order> findByIndex(String batchId);
 
     Optional<Order> findByBatchIdAndIndex(String id, String index);
 

--- a/src/main/java/pl/doublecodestudio/nexuserp/infrastructure/radius/order/persistence/JpaOrderRepository.java
+++ b/src/main/java/pl/doublecodestudio/nexuserp/infrastructure/radius/order/persistence/JpaOrderRepository.java
@@ -15,7 +15,7 @@ public interface JpaOrderRepository extends JpaRepository<JpaOrderEntity, Long> 
 
     List<JpaOrderEntity> findByStatus(String status);
 
-    List<JpaOrderEntity> findByIndex(String index, Pageable pageable);
+    List<JpaOrderEntity> findByIndex(String index);
 
     List<JpaOrderEntity> findByStatusAndOrderDateLessThanEqual(String status, Instant orderDate);
 

--- a/src/main/java/pl/doublecodestudio/nexuserp/infrastructure/radius/order/persistence/OrderRepositoryImpl.java
+++ b/src/main/java/pl/doublecodestudio/nexuserp/infrastructure/radius/order/persistence/OrderRepositoryImpl.java
@@ -33,8 +33,8 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public List<Order> findByIndex(String index, Pageable pageable) {
-        return repo.findByIndex(index, pageable).stream()
+    public List<Order> findByIndex(String index) {
+        return repo.findByIndex(index).stream()
                 .filter(item -> !Objects.equals(item.getStatus(), "Zamknięte"))
                 .map(mapper::toDomain)
                 .toList();


### PR DESCRIPTION
Change OrderRepository.findByIndex to non-paginated variant and update JPA repo + impl accordingly.

Adjust GetOrderByIndexQueryHandler to use the new signature, keep 'Ukończone' filter, and add @Slf4j with minimal diagnostics.