### PR TITLE
feat(user/security): derive change-password user from SecurityContext…

### DIFF
--- a/src/main/java/pl/doublecodestudio/nexuserp/application/user/command/ChangeUserPasswordCommand.java
+++ b/src/main/java/pl/doublecodestudio/nexuserp/application/user/command/ChangeUserPasswordCommand.java
@@ -1,4 +1,4 @@
 package pl.doublecodestudio.nexuserp.application.user.command;
 
-public record ChangeUserPasswordCommand(String username, String oldPassword, String newPassword) {
+public record ChangeUserPasswordCommand(String oldP, String newP) {
 }


### PR DESCRIPTION
…; rename payload fields to oldP/newP

Drop username from request and switch to authenticated principal (AccessDeniedException if unauthenticated). Validate oldP, set newP, persist, and log the action. BREAKING CHANGE: endpoint now expects { oldP, newP }.